### PR TITLE
WIP: Recognize XPS 15 7590 OLED variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /.cargo
 /target
 /vendor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "edid"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,8 +110,24 @@ dependencies = [
 
 [[package]]
 name = "memchr"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "nom"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "pkg-config"
@@ -136,14 +160,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "system76-oled"
 version = "0.1.3"
 dependencies = [
  "dbus 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "edid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "inotify 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11 2.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -172,6 +207,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "utf8-ranges"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi"
@@ -224,6 +269,7 @@ dependencies = [
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum dbus 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "48b5f0f36f1eebe901b0e6bee369a77ed3396334bf3f09abd46454a576f71819"
+"checksum edid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24ce75530893d834dcfe3bb67ce0e7dec489484e7cb4423ca31618af4bab24fe"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum inotify 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24e40d6fd5d64e2082e0c796495c8ef5ad667a96d03e5aaa0becfd9d47bcbfb8"
@@ -232,15 +278,19 @@ dependencies = [
 "checksum libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "d44e80633f007889c7eff624b709ab43c92d708caad982295768a7b13ca3b5eb"
 "checksum libdbus-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "69382cb3be797cfe62ba89ac5e594a0e3022914ff44867ffbcfc03daa24eebd7"
 "checksum log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c275b6ad54070ac2d665eef9197db647b32239c9d244bfb6f041a766d00da5b3"
+"checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
+"checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "d9d8297cc20bbb6184f8b45ff61c8ee6a9ac56c156cec8e38c3e5084773c44ad"
 "checksum regex-syntax 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "9b01330cce219c1c6b2e209e5ed64ccd587ae5c67bed91c0b49eecf02ae40e21"
+"checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d50aa7650df78abf942826607c62468ce18d9019673d4a2ebe1865dbb96ffde"
+"checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ inotify = { version = "0.7.0", default-features = false }
 libc = "0.2.60"
 log = { version = "0.4.7", features = ["release_max_level_debug"] }
 x11 = { version = "2.18.1", features = ["xlib", "xrandr"] }
+edid = "0.3"
+nom = "3.2"
+walkdir = "2.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -334,7 +334,7 @@ fn main() {
             _ => continue,
         };
 
-        let name = match display_dir.file_name().unwrap().to_str() {
+        let name = match display_dir.file_name().and_then(|s| s.to_str()) {
             Some(name) => name,
             _ => continue,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -464,7 +464,7 @@ fn main() {
 
         while current != requested {
             current = requested;
-            // Smooth transition (may require use of xlib for performance)
+            /* Smooth transition (may require use of xlib for performance)
             if current == !0 {
                 current = requested;
             } else if current < requested {
@@ -472,6 +472,7 @@ fn main() {
             } else if current > requested {
                 current -= 1;
             }
+            */
 
             xrandr_output_brightness(&mut display, &root_window, &output, if current == max {
                 None

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,12 +285,22 @@ fn main() {
     let vendor = fs::read_to_string("/sys/class/dmi/id/sys_vendor")
         .unwrap_or(String::new());
     let vendor = vendor.trim();
+
     let model = fs::read_to_string("/sys/class/dmi/id/product_version")
         .unwrap_or(String::new());
     let model = model.trim();
 
-    let output_opt = match (vendor, model) {
-        ("System76", "addw1") => Some("eDP-1"),
+    let sku = fs::read_to_string("/sys/class/dmi/id/product_sku")
+        .unwrap_or(String::new());
+    let sku = sku.trim();
+
+    let name = fs::read_to_string("/sys/class/dmi/id/product_sku")
+        .unwrap_or(String::new());
+    let name = name.trim();
+
+    let output_opt = match (vendor, name, model, sku) {
+        ("System76", _, "addw1", _) => Some("eDP-1"),
+        ("Dell Inc.", "XPS 15 7590", _, "0905") => Some("eDP-1"),
         _ => None,
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -294,7 +294,7 @@ fn main() {
         .unwrap_or(String::new());
     let sku = sku.trim();
 
-    let name = fs::read_to_string("/sys/class/dmi/id/product_sku")
+    let name = fs::read_to_string("/sys/class/dmi/id/product_name")
         .unwrap_or(String::new());
     let name = name.trim();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,10 +287,10 @@ struct EDIDInfo {
     vendor: [char; 3],
 }
 
+const KNOWN_OLED: &[EDIDInfo] = &[EDIDInfo { product_id: 41001, vendor: ['S', 'D', 'C'] }];
+
 fn main() {
     env_logger::from_env(Env::default().default_filter_or("info")).init();
-
-    let known_oled = [EDIDInfo { product_id: 41001, vendor: ['S', 'D', 'C'] }];
 
     let mut output_opt = None;
 
@@ -320,7 +320,7 @@ fn main() {
             vendor: edid.header.vendor,
         };
 
-        if !known_oled.contains(&info) {
+        if !KNOWN_OLED.contains(&info) {
             continue;
         }
 


### PR DESCRIPTION
This is a WIP pull request that does not currently work as desired.

The current behaviour is that running the tool while a non-max brightness is set it turns down the brightness as expected. However, attempting to further increase or decrease the brightness makes the brightness go to max brightness.

When trying to increase and decrease the brightness flashes of lower brightness can be seen. Could this be related to the two TODOs at the bottom about Mutter changing the gamma values?

Lastly, I added two new values to be looked at when determining the output. This was needed as the `version` is simply an empty file on the XPS 15 7590.

