### PR TITLE
Add limited compatibility for Lenovo X1 Yoga 2nd Gen

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -291,6 +291,7 @@ fn main() {
 
     let output_opt = match (vendor, model) {
         ("System76", "addw1") => Some("eDP-1"),
+        ("LENOVO", "ThinkPad X1 Yoga 2nd") => Some("eDP1"),
         _ => None,
     };
 


### PR DESCRIPTION
This does change the screen brightness. A couple of caveats:
- It doesn't work especially well with redshift. I'm not sure how to fix this, or if a proper fix even exists (I suspect it doesn't)
- Although it does dim and brighten the screen, I don't know how to tell if it's calibrated to the correct range. The screen is still somewhat visible at 0% but it is bright at 100%